### PR TITLE
Recording

### DIFF
--- a/Electron-vanillaJS-HTML/client/SPi-reader.rb
+++ b/Electron-vanillaJS-HTML/client/SPi-reader.rb
@@ -5,7 +5,7 @@
 require_relative 'SPi'
 
 def args
-  ARGV.join(' ')
+  ARGV.join(" ")
 end
 
 def run

--- a/Electron-vanillaJS-HTML/client/SPi-reader.rb
+++ b/Electron-vanillaJS-HTML/client/SPi-reader.rb
@@ -12,7 +12,7 @@ def run
   puts 'Running Spi-Reader.rb'
   app = SPiReader.new
   app.test_connection!
-  app.run(args)
+  app.identifyCommand(args)
 end
 
 run

--- a/Electron-vanillaJS-HTML/client/SPi.rb
+++ b/Electron-vanillaJS-HTML/client/SPi.rb
@@ -22,6 +22,7 @@ class SPiReader
 
   def identifyCommand(args)
     puts case args[0]
+
     when STOP_ARG
       stop()
 
@@ -32,7 +33,7 @@ class SPiReader
       stop_recording()
 
     when SAVE_RECORDING_ARG
-      save_recording()
+      save_recording(args[1])
 
     else
       run(args)
@@ -55,8 +56,8 @@ class SPiReader
     send_command(STOP_RECORDING_COMMAND)
   end
 
-  def save_recording
-    send_command(SAVE_RECORDING_COMMAND)
+  def save_recording(filename)
+    send_command(SAVE_RECORDING_COMMAND, filename)
   end
 
   def test_connection!

--- a/Electron-vanillaJS-HTML/client/SPi.rb
+++ b/Electron-vanillaJS-HTML/client/SPi.rb
@@ -30,7 +30,7 @@ class SPiReader
       stop-recording()
 
     else
-      run(command)
+      run(args)
     end
   end
 
@@ -54,7 +54,7 @@ class SPiReader
     begin
 	  OSC::Server.new(PORT)
     #TO-DO: Write an if branch here: if (!windows)
-	  #abort("Error: Sonic Pi not listening on #{PORT}")
+	  abort("Error: Sonic Pi not listening on #{PORT}")
 	rescue
 	  puts 'Sonic-pi running'
 	end

--- a/Electron-vanillaJS-HTML/client/SPi.rb
+++ b/Electron-vanillaJS-HTML/client/SPi.rb
@@ -9,8 +9,30 @@ class SPiReader
   PORT = 4557
   GUI_ID = 'SPi-Reader'
 
+  STOP_ARG = 'stop-all-jobs'
+  START_RECORDING_ARG = 'start-recording'
+  STOP_RECORDING_ARG = 'stop-recording'
+
   RUN_COMMAND = '/run-code'
   STOP_COMMAND = '/stop-all-jobs'
+  START_RECORDING_COMMAND = '/start-recording'
+  STOP_RECORDING_COMMAND = '/stop-recording'
+
+  def identifyCommand(args)
+    puts case args[0]
+    when STOP_ARG
+      stop()
+
+    when START_RECORDING_ARG
+      start_recording()
+
+    when STOP_RECORDING_ARG
+      stop-recording()
+
+    else
+      run(command)
+    end
+  end
 
   def run(command)
     send_command(RUN_COMMAND, command)
@@ -18,6 +40,14 @@ class SPiReader
 
   def stop
     send_command(STOP_COMMAND)
+  end
+
+  def start_recording
+    send_command(START_RECORDING_COMMAND)
+  end
+
+  def stop_recording
+    send_command(STOP_RECORDING_COMMAND)
   end
 
   def test_connection!

--- a/Electron-vanillaJS-HTML/client/SPi.rb
+++ b/Electron-vanillaJS-HTML/client/SPi.rb
@@ -9,10 +9,10 @@ class SPiReader
   PORT = 4557
   GUI_ID = 'SPi-Reader'
 
-  STOP_ARG = 'stop-all-jobs'
-  START_RECORDING_ARG = 'start-recording'
-  STOP_RECORDING_ARG = 'stop-recording'
-  SAVE_RECORDING_ARG = 'save-recording'
+  STOP_ARG = 'SAJ'
+  START_RECORDING_ARG = 'SRR'
+  STOP_RECORDING_ARG = 'SOR'
+  SAVE_RECORDING_ARG = 'SVR'
 
   RUN_COMMAND = '/run-code'
   STOP_COMMAND = '/stop-all-jobs'
@@ -21,8 +21,12 @@ class SPiReader
   SAVE_RECORDING_COMMAND = '/save-recording'
 
   def identifyCommand(args)
-    puts case args[0]
+    runcommand = args
+    args = args.split(" ")
 
+    puts 'args[0]' + ' ' + args[0]
+    
+    puts case (args[0])
     when STOP_ARG
       stop()
 
@@ -33,10 +37,12 @@ class SPiReader
       stop_recording()
 
     when SAVE_RECORDING_ARG
+      args[1].slice!(0)
+      #puts 'args[1]' + ' ' + args[1]
       save_recording(args[1])
 
     else
-      run(args)
+      run(runcommand)
     end
   end
 
@@ -57,6 +63,7 @@ class SPiReader
   end
 
   def save_recording(filename)
+    puts filename
     send_command(SAVE_RECORDING_COMMAND, filename)
   end
 
@@ -74,7 +81,8 @@ class SPiReader
 
   def send_command(call_type, command=nil)
     prepared_command = OSC::Message.new(call_type, GUI_ID, command)
-	client.send(prepared_command)
+    puts prepared_command
+    client.send(prepared_command)
   end
   
   def client

--- a/Electron-vanillaJS-HTML/client/SPi.rb
+++ b/Electron-vanillaJS-HTML/client/SPi.rb
@@ -12,11 +12,13 @@ class SPiReader
   STOP_ARG = 'stop-all-jobs'
   START_RECORDING_ARG = 'start-recording'
   STOP_RECORDING_ARG = 'stop-recording'
+  SAVE_RECORDING_ARG = 'save-recording'
 
   RUN_COMMAND = '/run-code'
   STOP_COMMAND = '/stop-all-jobs'
   START_RECORDING_COMMAND = '/start-recording'
   STOP_RECORDING_COMMAND = '/stop-recording'
+  SAVE_RECORDING_COMMAND = '/save-recording'
 
   def identifyCommand(args)
     puts case args[0]
@@ -27,7 +29,10 @@ class SPiReader
       start_recording()
 
     when STOP_RECORDING_ARG
-      stop-recording()
+      stop_recording()
+
+    when SAVE_RECORDING_ARG
+      save_recording()
 
     else
       run(args)
@@ -48,6 +53,10 @@ class SPiReader
 
   def stop_recording
     send_command(STOP_RECORDING_COMMAND)
+  end
+
+  def save_recording
+    send_command(SAVE_RECORDING_COMMAND)
   end
 
   def test_connection!

--- a/Electron-vanillaJS-HTML/control.js
+++ b/Electron-vanillaJS-HTML/control.js
@@ -1,10 +1,15 @@
 /**@module*/
 // Functions associated with forms and buttons on index.html are defined here.
 var shortcut=require('./mousetrap.js');
-var OSName = determineOS();
-
 var synth = window.speechSynthesis;
+
+// Server side
+var OSName = determineOS();
 var storeCode;
+
+const STOP_ARG = 'stop-all-jobs';
+const START_RECORDING_ARG = 'start-recording';
+const STOP_RECORDING_ARG = 'stop-recording';
 
 if('speechSynthesis' in window){
 
@@ -92,7 +97,7 @@ else
     	//console.log('saveCode() called');
     	console.log(storeCode);
 		// Functions associated with forms and buttons on index.html are defined here.
-		sendServer(storeCode);
+		return storeCode;
 	}
 
 	function formatCommands(storeCode) {
@@ -136,5 +141,17 @@ else
 					console.log('exec error: ' + error);
 				}
 			});
-
 		}
+
+	function play() {
+		var savedCode = saveCode();
+		sendServer(savedCode);
+	}
+
+	function startRecording() {
+		sendServer(START_RECORDING_ARG);
+	}
+
+	function stopRecording() {
+		sendServer(STOP_RECORDING_ARG);
+	}

--- a/Electron-vanillaJS-HTML/control.js
+++ b/Electron-vanillaJS-HTML/control.js
@@ -93,11 +93,9 @@ else
 		*/
 	function saveCode(){
     //Store the value in the text-field, which is the input from the user, into a variable
-    	var storeCode = document.getElementById('code').value;
-    	//console.log('saveCode() called');
+    	storeCode = document.getElementById('code').value;
+    	console.log('saveCode() called');
     	console.log(storeCode);
-		// Functions associated with forms and buttons on index.html are defined here.
-		return storeCode;
 	}
 
 	function formatCommands(storeCode) {
@@ -107,6 +105,7 @@ else
 
 		console.log("new code: "+newCode);
 		newCode = "\"" + newCode + "\"";
+
 		return newCode;
 	}
 
@@ -126,26 +125,26 @@ else
 			return;
 		}
 
-		storeCode = formatCommands(storeCode);
-		console.log('playing: ' + storeCode);
+		var code = formatCommands(storeCode);
+		console.log('playing: ' + code);
 
-		//TO-DO: Must handle the file convention separately for Mac & Windows
-		//For now, remember to change the backslash to slash when using Mac
 		var clientCommand = OSBasedClientCommand();
 		var exec = require('child_process').exec, child;
-		child = exec(clientCommand + storeCode,
+
+		child = exec(clientCommand + code,
 			function (error, stdout, stderr) {
 				console.log('stdout: ' + stdout);
 				console.log('stderr: ' + stderr);
 				if (error !== null) {
 					console.log('exec error: ' + error);
 				}
-			});
-		}
+			}
+		);
+	}
 
 	function play() {
-		var savedCode = saveCode();
-		sendServer(savedCode);
+		saveCode();
+		sendServer(storeCode);
 	}
 
 	function startRecording() {

--- a/Electron-vanillaJS-HTML/control.js
+++ b/Electron-vanillaJS-HTML/control.js
@@ -7,10 +7,10 @@ var synth = window.speechSynthesis;
 var OSName = determineOS();
 var storeCode;
 
-const STOP_ARG = 'stop-all-jobs';
-const START_RECORDING_ARG = 'start-recording';
-const STOP_RECORDING_ARG = 'stop-recording';
-const SAVE_RECORDING_ARG = 'save-recording';
+const STOP_ARG = 'SAJ';
+const START_RECORDING_ARG = 'SRR';
+const STOP_RECORDING_ARG = 'SOR';
+const SAVE_RECORDING_ARG = 'SVR';
 
 if('speechSynthesis' in window){
 
@@ -106,6 +106,7 @@ else
 
 	function startRecording() {
 		sendServer(false, START_RECORDING_ARG);
+		play();
 	}
 
 	function stopRecording() {
@@ -114,8 +115,11 @@ else
 	}
 
 	function saveRecording() {
-		console.log('Saving Recording');
-		var filename = 'test';
+		//var filepath = '/Users/ravi/Documents/SPi-Reader/music/';
+		var filepath = '~/Documents/'; // put slash at the end
+
+		var date = new Date();
+		var filename = filepath + 'sonic-pi-' + date.getTime() + '.wav';
 		sendServer(false, SAVE_RECORDING_ARG + ' ' + filename);
 		console.log('Saved Recording: ' + filename);
 	}
@@ -157,9 +161,10 @@ else
 	    }
 
 		var clientCommand = OSBasedClientCommand();
-		var exec = require('child_process').exec, child;
+		var command = clientCommand + code;
 
-		child = exec(clientCommand + code,
+		var exec = require('child_process').exec, child;
+		child = exec(command,
 			function (error, stdout, stderr) {
 				console.log('stdout: ' + stdout);
 				console.log('stderr: ' + stderr);

--- a/Electron-vanillaJS-HTML/control.js
+++ b/Electron-vanillaJS-HTML/control.js
@@ -10,6 +10,7 @@ var storeCode;
 const STOP_ARG = 'stop-all-jobs';
 const START_RECORDING_ARG = 'start-recording';
 const STOP_RECORDING_ARG = 'stop-recording';
+const SAVE_RECORDING_ARG = 'save-recording';
 
 if('speechSynthesis' in window){
 
@@ -94,8 +95,25 @@ else
 	function saveCode(){
     //Store the value in the text-field, which is the input from the user, into a variable
     	storeCode = document.getElementById('code').value;
-    	console.log('saveCode() called');
+    	//console.log('saveCode() called');
     	console.log(storeCode);
+	}
+
+	function play() {
+		saveCode();
+		sendServer(storeCode);
+	}
+
+	function startRecording() {
+		sendServer(START_RECORDING_ARG);
+	}
+
+	function stopRecording() {
+		sendServer(STOP_RECORDING_ARG);
+	}
+
+	function saveRecording() {
+		sendServer(SAVE_RECORDING_ARG);
 	}
 
 	function formatCommands(storeCode) {
@@ -140,17 +158,4 @@ else
 				}
 			}
 		);
-	}
-
-	function play() {
-		saveCode();
-		sendServer(storeCode);
-	}
-
-	function startRecording() {
-		sendServer(START_RECORDING_ARG);
-	}
-
-	function stopRecording() {
-		sendServer(STOP_RECORDING_ARG);
 	}

--- a/Electron-vanillaJS-HTML/control.js
+++ b/Electron-vanillaJS-HTML/control.js
@@ -101,19 +101,23 @@ else
 
 	function play() {
 		saveCode();
-		sendServer(storeCode);
+		sendServer(true, storeCode);
 	}
 
 	function startRecording() {
-		sendServer(START_RECORDING_ARG);
+		sendServer(false, START_RECORDING_ARG);
 	}
 
 	function stopRecording() {
-		sendServer(STOP_RECORDING_ARG);
+		sendServer(false, STOP_RECORDING_ARG);
+		saveRecording();
 	}
 
 	function saveRecording() {
-		sendServer(SAVE_RECORDING_ARG);
+		console.log('Saving Recording');
+		var filename = 'test';
+		sendServer(false, SAVE_RECORDING_ARG + ' ' + filename);
+		console.log('Saved Recording: ' + filename);
 	}
 
 	function formatCommands(storeCode) {
@@ -121,7 +125,6 @@ else
 		newCode = newCode.replace("do", "{");
 		newCode = newCode.replace("end", "}");
 
-		console.log("new code: "+newCode);
 		newCode = "\"" + newCode + "\"";
 
 		return newCode;
@@ -137,14 +140,21 @@ else
 		return clientCommand;
 	}
 
-	function sendServer(storeCode) {
+	function sendServer(needFormatting, storeCode) {
 		if(storeCode == null) {
 			console.log('buffer is empty');
 			return;
 		}
 
-		var code = formatCommands(storeCode);
-		console.log('playing: ' + code);
+		code = storeCode;
+
+		if(needFormatting) {
+			code = formatCommands(storeCode);
+			console.log('playing: ' + code);
+	    }
+	    else {
+	    	console.log(code);
+	    }
 
 		var clientCommand = OSBasedClientCommand();
 		var exec = require('child_process').exec, child;

--- a/Electron-vanillaJS-HTML/index.html
+++ b/Electron-vanillaJS-HTML/index.html
@@ -12,11 +12,11 @@
 
  <fieldset>
     <textarea class="mousetrap" id="code" data-gramm="true" spellcheck="false" data-gramm_editor="true" style="z-index: auto; position: relative; line-height: normal; font-size: 12px; transition: none; background: transparent !important;width:500px;height:200px;padding:20px"></textarea>
-    <input class="mousetrap" id="play" type="button" value="Play" onclick="saveCode()" style="width: 50px; height: 30px;">
+    <input class="mousetrap" id="play" type="button" value="Play" onclick="play()" style="width: 50px; height: 30px;">
  </fieldset>
-        <input class="mousetrap" id="save" type="button" value="Save" onclick="" style="width: 50px; height: 30px; margin: 20px">
+        <input class="mousetrap" id="save" type="button" value="Save" onclick="startRecording()" style="width: 50px; height: 30px; margin: 20px">
 
-        <input class="mousetrap" id="load" type="button" value="Load" style="width: 50px; height: 30px; margin: 20px;" onclick="">
+        <input class="mousetrap" id="load" type="button" value="Load" onclick="stopRecording()" style="width: 50px; height: 30px; margin: 20px;">
 
 </body>
 </html>
@@ -30,4 +30,3 @@
  <script type="text/javascript" src = "http://localhost:8080/webpack-dev-server.js"></script>
 <script type="text/javascript" src="http://localhost:8080/build/bundle.js"></script>
 </html>
-


### PR DESCRIPTION
On this branch, the save and load buttons are start and stop record buttons, just to test out the functionality. We can reroute the methods to the proper places on your UI revamp. Other than that, all changes have been in the control.js and two ruby client files.

Recording: start, stop and save works but there are limitations:

Recordings are saved in the documents folder under home by default and if the user deletes it, the recording can't save at all. I tried relative paths using '../' but it causes issues for an unknown reason and does not save the file either. 

I can change the code to add custom file names quite quickly once we have the GUI portion for the user to enter that. For now, the name is given using the date.getTime() method (milliseconds since 1/1/1970). 

Visually impaired users can accidentally make the recording longer than it needs to be by missing the stop recording button, I made it so that the buffer automatically plays when start record button is pressed but the user has free reign on when recording stops, even when the music is long over. I'm not yet sure how to make it so that stop recording is called immediately when the music stops.
